### PR TITLE
apply __encode_inner before urllib.urlencode

### DIFF
--- a/unirest/__init__.py
+++ b/unirest/__init__.py
@@ -170,7 +170,7 @@ def get(url, **kwargs):
             url += "?"
         else:
             url += "&"
-        url += urllib.urlencode(dict((k, v) for k, v in params.iteritems() if v is not None)) # Removing None values
+        url += urllib.urlencode(__encode_inner(dict((k, v) for k, v in params.iteritems() if v is not None))) # Removing None values/encode unicode objects
 
     return __dorequest("GET", url, {}, kwargs.get(HEADERS_KEY, {}), kwargs.get(AUTH_KEY, None), kwargs.get(CALLBACK_KEY, None))
     

--- a/unirest/test/test_unirest.py
+++ b/unirest/test/test_unirest.py
@@ -1,3 +1,5 @@
+# -*- coding:utf-8 -*-
+
 import sys
 import os
 import unittest
@@ -12,6 +14,14 @@ class UnirestTestCase(unittest.TestCase):
 		self.assertEqual(len(response.body['args']), 2)
 		self.assertEqual(response.body['args']['name'], "Mark")
 		self.assertEqual(response.body['args']['nick'], "thefosk")
+
+
+        def test_get_unicode_param(self):
+                response = unirest.get('http://httpbin.org/get?name=Shimada', params={"nick":u"しまりん"})
+                self.assertEqual(response.code, 200)
+                self.assertEqual(len(response.body['args']), 2)
+                self.assertEqual(response.body['args']['name'], "Shimada")
+                self.assertEqual(response.body['args']['nick'], u"しまりん")
 
 	def test_get_none_param(self):
 		response = unirest.get('http://httpbin.org/get?name=Mark', params={"nick":"thefosk", "age": None, "third":""})


### PR DESCRIPTION
because urllib.urlencode is not capable of encoding dicts contain unicode objects
