### PR TITLE
Set time out as deadline when using urlfetch library

### DIFF
--- a/unirest/__init__.py
+++ b/unirest/__init__.py
@@ -86,7 +86,7 @@ def __request(method, url, params={}, headers={}, auth=None, callback=None):
 
     _unirestResponse = None
     if _httplib == "urlfetch":
-        res = urlfetch.fetch(url, payload=data, headers=headers, method=method)
+        res = urlfetch.fetch(url, payload=data, headers=headers, method=method, deadline=_timeout)
         _unirestResponse = UnirestResponse(res.status_code,
                                            res.headers,
                                            res.content)


### PR DESCRIPTION
Currently the global time out value is not respected when using urlfetch
library. This change make sure have consistency of using timeout across
whichever HTTP I/O library we are using.

Signed-off-by: Imran M Yousuf <imyousuf@newscred.com>