### PR TITLE
Be explicit in the relative import of utils

### DIFF
--- a/unirest/__init__.py
+++ b/unirest/__init__.py
@@ -27,7 +27,7 @@ import urllib
 import base64
 import threading
 import gzip
-import utils
+from . import utils
 
 from StringIO import StringIO
 from poster.streaminghttp import register_openers


### PR DESCRIPTION
This avoids issues with ambiguity determining what utils you want to import if you move the unirest package around and end up with more "utils" modules in your python path.