### PR TITLE
Except block for urllib2.URLError

### DIFF
--- a/unirest/__init__.py
+++ b/unirest/__init__.py
@@ -98,6 +98,7 @@ def __request(method, url, params={}, headers={}, auth=None, callback=None):
             response = urllib2.urlopen(req, timeout=_timeout)
             _unirestResponse = UnirestResponse(response.code, response.headers, response.read())
         except urllib2.HTTPError, e:
+            response = e
             _unirestResponse = UnirestResponse(response.code, response.headers, response.read())
         except urllib2.URLError, e:
             _unirestResponse = UnirestResponse(0, {}, str(e.reason))

--- a/unirest/__init__.py
+++ b/unirest/__init__.py
@@ -45,14 +45,12 @@ _timeout = 10
 _httplib = None
 try:
     from google.appengine.api import urlfetch
-
     _httplib = 'urlfetch'
 except ImportError:
     pass
 
 if not _httplib:
     import urllib2
-
     _httplib = "urllib2"
 
 # Register the streaming http handlers
@@ -60,6 +58,7 @@ register_openers()
 
 
 def __request(method, url, params={}, headers={}, auth=None, callback=None):
+
     # Encode URL
     url_parts = url.split("\\?")
     url = url_parts[0].replace(" ", "%20")
@@ -139,28 +138,23 @@ def get(url, **kwargs):
         url += utils.dict2query(
             dict((k, v) for k, v in params.iteritems() if v is not None))  # Removing None values/encode unicode objects
 
-    return __dorequest("GET", url, {}, kwargs.get(HEADERS_KEY, {}), kwargs.get(AUTH_KEY, None),
-                       kwargs.get(CALLBACK_KEY, None))
+    return __dorequest("GET", url, {}, kwargs.get(HEADERS_KEY, {}), kwargs.get(AUTH_KEY, None), kwargs.get(CALLBACK_KEY, None))
 
 
 def post(url, **kwargs):
-    return __dorequest("POST", url, get_parameters(kwargs), kwargs.get(HEADERS_KEY, {}), kwargs.get(AUTH_KEY, None),
-                       kwargs.get(CALLBACK_KEY, None))
+    return __dorequest("POST", url, get_parameters(kwargs), kwargs.get(HEADERS_KEY, {}), kwargs.get(AUTH_KEY, None), kwargs.get(CALLBACK_KEY, None))
 
 
 def put(url, **kwargs):
-    return __dorequest("PUT", url, get_parameters(kwargs), kwargs.get(HEADERS_KEY, {}), kwargs.get(AUTH_KEY, None),
-                       kwargs.get(CALLBACK_KEY, None))
+    return __dorequest("PUT", url, get_parameters(kwargs), kwargs.get(HEADERS_KEY, {}), kwargs.get(AUTH_KEY, None), kwargs.get(CALLBACK_KEY, None))
 
 
 def delete(url, **kwargs):
-    return __dorequest("DELETE", url, get_parameters(kwargs), kwargs.get(HEADERS_KEY, {}), kwargs.get(AUTH_KEY, None),
-                       kwargs.get(CALLBACK_KEY, None))
+    return __dorequest("DELETE", url, get_parameters(kwargs), kwargs.get(HEADERS_KEY, {}), kwargs.get(AUTH_KEY, None), kwargs.get(CALLBACK_KEY, None))
 
 
 def patch(url, **kwargs):
-    return __dorequest("PATCH", url, get_parameters(kwargs), kwargs.get(HEADERS_KEY, {}), kwargs.get(AUTH_KEY, None),
-                       kwargs.get(CALLBACK_KEY, None))
+    return __dorequest("PATCH", url, get_parameters(kwargs), kwargs.get(HEADERS_KEY, {}), kwargs.get(AUTH_KEY, None), kwargs.get(CALLBACK_KEY, None))
 
 
 def default_header(name, value):

--- a/unirest/__init__.py
+++ b/unirest/__init__.py
@@ -102,10 +102,10 @@ def __request(method, url, params={}, headers={}, auth=None, callback=None):
         except urllib2.URLError, e:
             _unirestResponse = UnirestResponse(0, {}, str(e.reason))
 
-        if callback is None or callback == {}:
-            return _unirestResponse
-        else:
-            callback(_unirestResponse)
+    if callback is None or callback == {}:
+        return _unirestResponse
+    else:
+        callback(_unirestResponse)
 
 # The following methods in the Mashape class are based on
 # Stripe's python bindings which are under the MIT license.
@@ -135,8 +135,7 @@ def get(url, **kwargs):
             url += "?"
         else:
             url += "&"
-        url += utils.dict2query(
-            dict((k, v) for k, v in params.iteritems() if v is not None))  # Removing None values/encode unicode objects
+        url += utils.dict2query(dict((k, v) for k, v in params.iteritems() if v is not None))  # Removing None values/encode unicode objects
 
     return __dorequest("GET", url, {}, kwargs.get(HEADERS_KEY, {}), kwargs.get(AUTH_KEY, None), kwargs.get(CALLBACK_KEY, None))
 


### PR DESCRIPTION
Based on visham/a271e16 (aka PR #26)

A line got lost when reworking the try/except blocks. This line is needed to bind "response" to an appropriate object to pass to UnirestResponse.